### PR TITLE
Update package.json using style from generator-hubot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,33 @@
 {
   "name": "hubot-maps",
-  "version": "0.0.0",
   "description": "A Hubot script for searching maps and directions",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "version": "0.0.0",
+  "author": "gkoo",
+  "license": "MIT",
   "keywords": [
     "hubot",
+    "hubot-scripts"
     "google",
     "maps",
     "directions"
   ],
-  "author": "gkoo",
-  "license": "MIT"
+
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/gkoo/hubot-maps.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gkoo/hubot-maps/issues"
+  },
+
+  "main": "index.coffee",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+
+  "dependencies": {},
+
+  "peerDependencies": {
+    "hubot": "2.x"
+  },
 }


### PR DESCRIPTION
I'm working on extracting the default hubot scripts out into NPM packages, so newly generated bots can use that instead of having them live in a newly generated bot. As part of that, I put together a generator at https://github.com/technicalpickles/generator-hubot (unreleased, but will move it to github or hubot-scripts org once it's done). It looks like you extracted maps.coffee already though, with even a few improvements!

This are some minor cleanups to the package.json:
- re-order the fields to follow sty
- make sure to link to the repository & bugs
- make sure hubot-scripts is a keyword

I think the repository one is the most important, as it took me a bit of googling to track down the source for this. I also intend to eventually use the hubot-scripts keyword as a way to discover scripts on npm.
