### PR TITLE
Change URI encoding method from encode to encodeURIComponent

### DIFF
--- a/src/maps.coffee
+++ b/src/maps.coffee
@@ -57,15 +57,15 @@ module.exports = (robot) ->
     mapType  = msg.match[1] or "roadmap"
     location = fillAddress(msg.match[3])
     mapUrl   = "http://maps.google.com/maps/api/staticmap?markers=" +
-                escape(location) +
+                encodeURIComponent(location) +
                 "&size=400x400&maptype=" +
                 mapType +
                 "&sensor=false" +
                 "&format=png" # So campfire knows it's an image
     url      = "http://maps.google.com/maps?q=" +
-               escape(location) +
+               encodeURIComponent(location) +
               "&hl=en&sll=37.0625,-95.677068&sspn=73.579623,100.371094&vpsrc=0&hnear=" +
-              escape(location) +
+              encodeURIComponent(location) +
               "&t=m&z=11"
 
     msg.send mapUrl


### PR DESCRIPTION
Change URI encoding method from encode to encodeURIComponent
Because encode method can not encode multibyte strings to URI format