### PR TITLE
fix fillAddress() crash and support mutli-byte characters on query

### DIFF
--- a/src/maps.coffee
+++ b/src/maps.coffee
@@ -55,17 +55,17 @@ module.exports = (robot) ->
 
   robot.respond /(?:(satellite|terrain|hybrid)[- ])?map( me)? (.+)/i, (msg) ->
     mapType  = msg.match[1] or "roadmap"
-    location = fillAddress(msg.match[3])
+    location = encodeURIComponent(msg.match[3])
     mapUrl   = "http://maps.google.com/maps/api/staticmap?markers=" +
-                escape(location) +
+                location +
                 "&size=400x400&maptype=" +
                 mapType +
                 "&sensor=false" +
                 "&format=png" # So campfire knows it's an image
     url      = "http://maps.google.com/maps?q=" +
-               escape(location) +
+               location +
               "&hl=en&sll=37.0625,-95.677068&sspn=73.579623,100.371094&vpsrc=0&hnear=" +
-              escape(location) +
+              location +
               "&t=m&z=11"
 
     msg.send mapUrl


### PR DESCRIPTION
Hi gkoo,

I faced crashing 'map me' on hubot, because of missing fillAddress() function,
I cannot find which module I should install to fix it, so simply remove it,
on the other hand, I found that I cannot get any maps if I asked location by Japanese characters, we need URI encoding for these query.

so, I also put it instead of escape(),

it is great if you pull this or fixed these issues in your way,

Thank you,


* remove fillAddress() due to missing it.
* use 'encodeURIComponent()' instead of 'escape()' to support multi-byte
  characters on query like Japanese.